### PR TITLE
Fix(Pet): Handle case-insensitivity when purchasing pets

### DIFF
--- a/src/main/java/com/karta/petsplus/storage/YamlStorage.java
+++ b/src/main/java/com/karta/petsplus/storage/YamlStorage.java
@@ -95,7 +95,7 @@ public class YamlStorage implements Storage {
     @Override
     public void addPet(Player player, String petType) {
         String displayName = plugin.getConfigManager().getPets().getString("pets." + petType + ".display-name", "My Pet");
-        Pet newPet = new Pet(player.getUniqueId(), PetType.valueOf(petType), displayName);
+        Pet newPet = new Pet(player.getUniqueId(), PetType.valueOf(petType.toUpperCase(java.util.Locale.ROOT)), displayName);
         playerPetCache.computeIfAbsent(player.getUniqueId(), k -> new ArrayList<>()).add(newPet);
     }
 


### PR DESCRIPTION
Resolves an `IllegalArgumentException` that occurred when purchasing a pet from the pet shop. The error was caused by calling `PetType.valueOf()` with a lowercase pet type string (e.g., "goat") while the enum constants are in uppercase (e.g., "GOAT").

The `addPet` method in `YamlStorage` has been modified to convert the pet type string to uppercase before calling `PetType.valueOf()`, ensuring the correct enum constant is found.